### PR TITLE
removing call to $wpdb->escape which has been deprecated since 3.6.

### DIFF
--- a/sunrise.php
+++ b/sunrise.php
@@ -8,7 +8,7 @@ if ( defined( 'COOKIE_DOMAIN' ) ) {
 
 // let the site admin page catch the VHOST == 'no'
 $wpdb->dmtable = $wpdb->base_prefix . 'domain_mapping';
-$dm_domain = $wpdb->escape( $_SERVER[ 'HTTP_HOST' ] );
+$dm_domain = $_SERVER[ 'HTTP_HOST' ];
 
 if( ( $nowww = preg_replace( '|^www\.|', '', $dm_domain ) ) != $dm_domain )
 	$where = $wpdb->prepare( 'domain IN (%s,%s)', $dm_domain, $nowww );


### PR DESCRIPTION
$wpdb->prepare will already properly escape the value
